### PR TITLE
Fix image thumbnails. - feed + meta page

### DIFF
--- a/src/components/feed/ImageThumb.tsx
+++ b/src/components/feed/ImageThumb.tsx
@@ -5,6 +5,7 @@ import { constants } from "@/constants";
 
 import Image from "next/image";
 import Link from "next/link";
+import { getImageUrl } from "@/utils/imageUrl";
 
 const ImageThumb = ({ token, index }: any) => {
   const imageUrl = token?.media;
@@ -27,9 +28,7 @@ const ImageThumb = ({ token, index }: any) => {
     );
 
   if (imageUrl) {
-    const finalUrl = imageUrl.includes("https://arweave.net")
-      ? imageUrl
-      : `https://arweave.net/${imageUrl}`;
+    const finalUrl = getImageUrl(imageUrl);
 
     return (
       <div className=" aspect-square  sm:w-full md:w-72 h-72 xl:w-80 xl:h-80 relative">

--- a/src/components/feed/ImageThumb.tsx
+++ b/src/components/feed/ImageThumb.tsx
@@ -27,6 +27,10 @@ const ImageThumb = ({ token, index }: any) => {
     );
 
   if (imageUrl) {
+    const finalUrl = imageUrl.includes("https://arweave.net")
+      ? imageUrl
+      : `https://arweave.net/${imageUrl}`;
+
     return (
       <div className=" aspect-square  sm:w-full md:w-72 h-72 xl:w-80 xl:h-80 relative">
         <Link
@@ -37,7 +41,7 @@ const ImageThumb = ({ token, index }: any) => {
         >
           <Image
             key={token?.metadata_id}
-            src={`https://image-cache-service-z3w7d7dnea-ew.a.run.app/thumbnail?url=${imageUrl}`}
+            src={`https://image-cache-service-z3w7d7dnea-ew.a.run.app/thumbnail?url=${finalUrl}`}
             alt={`Token ${index}`}
             className="object-cover h-full w-full"
             width={320}
@@ -53,9 +57,13 @@ const ImageThumb = ({ token, index }: any) => {
             onClick={(e) => {
               e.preventDefault();
               window.open(
-              `https://twitter.com/intent/tweet?url=%0aCheck%20out%20mine%3A%20${window.location.origin}/meta/${decodeURIComponent(token?.metadata_id)}%2F&via=mintbase&text=${constants.twitterText}`,
-              "_blank"
-            );
+                `https://twitter.com/intent/tweet?url=%0aCheck%20out%20mine%3A%20${
+                  window.location.origin
+                }/meta/${decodeURIComponent(
+                  token?.metadata_id
+                )}%2F&via=mintbase&text=${constants.twitterText}`,
+                "_blank"
+              );
             }}
           >
             Share

--- a/src/components/metaPage.tsx
+++ b/src/components/metaPage.tsx
@@ -6,8 +6,11 @@ import { motion } from "framer-motion";
 import Link from "next/link";
 import { constants } from "@/constants";
 import InlineSVG from "react-inlinesvg";
+import { getImageUrl } from "@/utils/imageUrl";
 
 export const MetaPage = ({ meta, slug }: any) => {
+  const finalUrl = getImageUrl(meta?.data?.nft_metadata?.[0]?.media);
+
   return (
     <motion.div
       initial={{ opacity: 0 }}
@@ -19,7 +22,7 @@ export const MetaPage = ({ meta, slug }: any) => {
       <div className="md:w-[468px] md:h-[468px] relative">
         <Image
           alt={meta?.data?.nft_metadata?.[0]?.title}
-          src={meta?.data?.nft_metadata?.[0]?.media}
+          src={finalUrl}
           width="468"
           height="468"
         />
@@ -28,7 +31,11 @@ export const MetaPage = ({ meta, slug }: any) => {
           onClick={(e) => {
             e.preventDefault();
             window.open(
-              `https://twitter.com/intent/tweet?url=%0aCheck%20out%20mine%3A%20${window.location.origin}/meta/${decodeURIComponent(slug)}%2F&via=mintbase&text=${constants.twitterText}`,
+              `https://twitter.com/intent/tweet?url=%0aCheck%20out%20mine%3A%20${
+                window.location.origin
+              }/meta/${decodeURIComponent(slug)}%2F&via=mintbase&text=${
+                constants.twitterText
+              }`,
               "_blank"
             );
           }}

--- a/src/utils/imageUrl.ts
+++ b/src/utils/imageUrl.ts
@@ -1,0 +1,7 @@
+export const getImageUrl = (imageUrl: string) => {
+  if (!imageUrl) return "";
+
+  return imageUrl.includes("https://arweave.net")
+    ? imageUrl
+    : `https://arweave.net/${imageUrl}`;
+};


### PR DESCRIPTION
This PR adds the arweave base url, if the media field doesn't have it present.

Solves the problem where nfts that have image are displaying the error message when they have media.